### PR TITLE
Added basic barline and repeat support

### DIFF
--- a/musicxml2.cabal
+++ b/musicxml2.cabal
@@ -1,6 +1,6 @@
 
 name:                   musicxml2
-version:                1.8.1
+version:                1.8.2
 synopsis:               A representation of the MusicXML format.
 author:                 Hans Hoglund
 maintainer:             Hans Hoglund

--- a/src/Music/MusicXml/Score.hs
+++ b/src/Music/MusicXml/Score.hs
@@ -75,6 +75,14 @@ module Music.MusicXml.Score (
         Direction(..),
 
         -----------------------------------------------------------------------------
+        -- ** Barlines
+        Barline(..),
+        BarStyle(..),
+        BarlineLocation(..),
+        Repeat(..),
+        RepeatDirection(..),
+
+        -----------------------------------------------------------------------------
         -- ** Lyrics
 
         Lyric(..),
@@ -262,11 +270,12 @@ data MusicElem
         Note
     | MusicDirection
         Direction
+    | MusicBarline                 
+        Barline
     | MusicHarmony                      -- TODO
     | MusicFiguredBass                  -- TODO
     | MusicPrint                        -- TODO
     | MusicSound                        -- TODO
-    | MusicBarline                      -- TODO
     | MusicGrouping                     -- TODO
     | MusicLink                         -- TODO
     | MusicBookmark                     -- TODO
@@ -528,6 +537,53 @@ data Direction
     | Percussion                        -- TODO
     | OtherDirection
         String
+
+
+-- ----------------------------------------------------------------------------------
+-- Barlines/Repeats
+-- ----------------------------------------------------------------------------------
+
+-- TODO: footnote, level, wavyLine, segno, coda, fermata, ending, divisions
+data Barline = Barline 
+             BarlineLocation
+             BarStyle
+             (Maybe Repeat)
+ deriving (Show,Eq)
+
+-- TODO: color
+data BarStyle = BSRegular|BSDotted|BSDashed|BSHeavy|BSLightLight|
+                BSLightHeavy|BSHeavyLight|BSHeavyHeavy|BSTick|
+                BSShort|BSNone deriving (Eq,Enum)
+
+instance Show BarStyle where 
+    show BSRegular = "regular"
+    show BSDotted = "dotted"
+    show BSDashed = "dashed"
+    show BSHeavy = "heavy"
+    show BSLightLight = "light-light"
+    show BSLightHeavy = "light-heavy"
+    show BSHeavyLight = "heavy-light"
+    show BSHeavyHeavy = "heavy-heavy"
+    show BSTick = "tick"
+    show BSShort = "short"
+    show BSNone = "none"
+
+-- TODO: times
+data Repeat = Repeat RepeatDirection deriving (Eq,Show)
+
+data RepeatDirection = RepeatBackward|RepeatForward deriving (Eq)
+
+instance Show RepeatDirection where 
+    show RepeatForward = "forward"
+    show RepeatBackward = "backward"
+
+data BarlineLocation = BLRight|BLLeft|BLMiddle deriving (Eq)
+
+instance Show BarlineLocation where
+    show BLRight = "right"
+    show BLLeft = "left"
+    show BLMiddle = "middle"
+
 
 
 -- ----------------------------------------------------------------------------------

--- a/src/Music/MusicXml/Simple.hs
+++ b/src/Music/MusicXml/Simple.hs
@@ -215,6 +215,14 @@ module Music.MusicXml.Simple (
         coda,
 
         -----------------------------------------------------------------------------
+        -- * Barlines/Repeats
+        -----------------------------------------------------------------------------
+        barline,
+        doubleBarline,
+        beginRepeat,
+        endRepeat,
+
+        -----------------------------------------------------------------------------
         -- * Folds and maps
         -----------------------------------------------------------------------------
         
@@ -436,6 +444,24 @@ backup d = Music . single $ MusicBackup d
 
 forward :: Duration -> Music
 forward d = Music . single $ MusicForward d
+
+-- ----------------------------------------------------------------------------------
+-- Barlines
+-- ----------------------------------------------------------------------------------
+
+-- | All-purpose barline function.
+barline :: Barline -> Music
+barline = Music . single . MusicBarline
+
+-- | Inserts double bar at beginning of bar.
+doubleBarline :: Music
+doubleBarline = barline $ Barline BLLeft BSLightLight Nothing
+
+beginRepeat :: Music
+beginRepeat = barline $ Barline BLLeft BSHeavyLight $ Just $ Repeat RepeatForward
+
+endRepeat :: Music
+endRepeat = barline $ Barline BLRight BSLightHeavy $ Just $ Repeat RepeatBackward
 
 -- ----------------------------------------------------------------------------------
 -- Notes

--- a/src/Music/MusicXml/Write/Score.hs
+++ b/src/Music/MusicXml/Write/Score.hs
@@ -150,6 +150,7 @@ instance WriteMusicXml MusicElem where
     write (MusicDirection x)  = single $ unode "direction" (unode "direction-type" $ write x)
     write (MusicBackup d)     = single $ unode "backup" (unode "duration" $ show $ getDivs $ d)
     write (MusicForward d)    = single $ unode "forward" (unode "duration" $ show $ getDivs $ d)
+    write (MusicBarline x)    = write x
 
 -- ----------------------------------------------------------------------------------
 -- Attributes
@@ -409,6 +410,19 @@ instance WriteMusicXml Direction where
     write Bracket                               = notImplemented "Unsupported directions"
     write (OtherDirection dir)                  = notImplemented "OtherDirection"
 
+-- ----------------------------------------------------------------------------------
+-- Barline
+-- ----------------------------------------------------------------------------------
+
+instance WriteMusicXml Barline where
+    write (Barline location style repeat) = single $ 
+                                            addAttr (uattr "location" (show location)) $ 
+                                            unode "barline" $ 
+                                            [unode "bar-style" (show style)] <> 
+                                            maybe [] write repeat
+
+instance WriteMusicXml Repeat where
+    write (Repeat dir) = single $ addAttr (uattr "direction" (show dir)) $ unode "repeat" ()
 
 -- ----------------------------------------------------------------------------------
 -- Lyrics


### PR DESCRIPTION
Hello! I have tested these changes (at least double bars, start and end repeats) in my project using musicxml2. I didn't want to mess with your tests, but as you can guess simply add "doubleBarline", "beginRepeat", "endRepeat" to try it out. Supports a basic subset, TODOs in Write/Score.hs document what's missing. Thanks!! Stuart
